### PR TITLE
LOG-165: Allow setting the Fluree client ledger

### DIFF
--- a/libs/fluree/package.json
+++ b/libs/fluree/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@logosphere/fluree",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "./src/index.js"
 }

--- a/libs/fluree/src/fluree.client.ts
+++ b/libs/fluree/src/fluree.client.ts
@@ -90,6 +90,14 @@ export class FlureeClient {
   }
 
   /**
+   * Changes the ledger the client operates with for queries and transactions
+   * @param ledger The ledger the client will use for queries and transactions
+   */
+  setLedger(ledger: string) {
+    this.#config.ledger = ledger;
+  }
+
+  /**
    * Fetches a list of ledgers assocated with the current connection
    * @returns An array of ledger names
    */

--- a/libs/fluree/src/fluree.util.ts
+++ b/libs/fluree/src/fluree.util.ts
@@ -5,7 +5,9 @@
  * @returns duration as number of milliseconds
  */
 export function processFlureeDuration(duration: string): number {
-  if (duration.indexOf('ms') > 0) {
+  if (duration === null || duration === undefined) {
+    return -1;
+  } else if (duration.indexOf('ms') > 0) {
     return +duration.replace('ms', '');
   } else if (duration.indexOf('s') > 0) {
     return +duration.replace('s', '') * 1000;


### PR DESCRIPTION
Fluree client currently can have ledger set at time of initialization.  This allows to change the set ledger during usage. Mostly useful for testing where we create a dynamic ledger at runtime.