### PR TITLE
fix(log-215): e2e tests fix + handling optional query selection in repos

### DIFF
--- a/libs/converters/src/utils/prop-example.ts
+++ b/libs/converters/src/utils/prop-example.ts
@@ -24,15 +24,22 @@ export function propExample(prop: Property, random = false) {
     case DefinitionType.ScalarArray:
       switch (prop.type) {
         case 'string':
-          ret = val
-            ? val
-            : rs.generate({
-                length: prop.maxLength,
-                charset: 'alphabetic',
-              });
+          if (val) {
+            ret = prop.isUnique
+              ? `${val}${rs.generate({
+                  length: prop.maxLength,
+                  charset: 'alphabetic',
+                })}`
+              : val;
+          } else {
+            ret = rs.generate({
+              length: prop.maxLength,
+              charset: 'alphabetic',
+            });
+          }
           break;
         case 'number':
-          ret = val ? +val : Math.floor(Math.random() * 10);
+          ret = Math.floor(Math.random() * 10);
           break;
         case 'boolean':
           ret = random ? getRandom([true, false]) : true;

--- a/libs/sdk/src/generators/api-e2e/api-e2e.ts
+++ b/libs/sdk/src/generators/api-e2e/api-e2e.ts
@@ -16,7 +16,7 @@ import {
 } from '@logosphere/converters';
 import { strings } from '@angular-devkit/core';
 import { DEFAULT_FIXTURE_DEPTH } from '../../common';
-import { tsFormatter } from '../utils';
+import { tsFormatter, gqlFormatter } from '../utils';
 import { ApiE2eGeneratorSchema } from './schema';
 import { applicationGenerator } from '../application';
 import { initGenerator } from '../init';
@@ -63,6 +63,7 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
     ...options,
     ...strings,
     ...tsFormatter,
+    ...gqlFormatter,
     ...names(options.projectDirectory),
     offsetFromRoot: offsetFromRoot(options.projectRoot),
     npmScope: getWorkspaceLayout(tree).npmScope,

--- a/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/mutations/__name__-create.gql
+++ b/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/mutations/__name__-create.gql
@@ -1,11 +1,3 @@
 mutation <%= camelize(name) %>Create($<%= camelize(name) %>: <%= classify(name) %>Input!){
-  <%= camelize(name) %>Save(<%= camelize(name) %>: $<%= camelize(name) %>){
-    id,
-    subjectId,
-    <%_ definition.props.filter((p) => p.defType !== 'Entity' && p.defType !== 'EntityArray').map((p) => { -%>
-    <%= camelize(p.name) %>,
-    <%_ }) -%>
-    createdAt,
-    updatedAt
-  }
+  <%= camelize(name) %>Save(<%= camelize(name) %>: $<%= camelize(name) %>)<%= gql(index, definition.name, fixtureDepth) %>
 }

--- a/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/mutations/__name__-update.gql
+++ b/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/mutations/__name__-update.gql
@@ -1,11 +1,3 @@
 mutation <%= camelize(name) %>Update($<%= camelize(name) %>: <%= classify(name) %>Input!){
-  <%= camelize(name) %>Save(<%= camelize(name) %>: $<%= camelize(name) %>){
-    id,
-    subjectId,
-    <%_ definition.props.filter((p) => p.defType !== 'Entity' && p.defType !== 'EntityArray').map((p) => { -%>
-    <%= camelize(p.name) %>,
-    <%_ }) -%>
-    createdAt,
-    updatedAt
-  }
+  <%= camelize(name) %>Save(<%= camelize(name) %>: $<%= camelize(name) %>)<%= gql(index, definition.name, fixtureDepth) %>
 }

--- a/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/queries/__name__-find-all.gql
+++ b/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/queries/__name__-find-all.gql
@@ -1,11 +1,3 @@
 query <%= camelize(name) %>FindAll{
-  <%= camelize(name) %>FindAll{
-    id,
-    subjectId,
-    <%_ definition.props.filter((p) => p.defType !== 'Entity' && p.defType !== 'EntityArray').map((p) => { -%>
-    <%= camelize(p.name) %>,
-    <%_ }) -%>
-    createdAt,
-    updatedAt
-  }
+  <%= camelize(name) %>FindAll<%= gql(index, definition.name, fixtureDepth) %>
 }

--- a/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/queries/__name__-find-many-by-id.gql
+++ b/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/queries/__name__-find-many-by-id.gql
@@ -1,11 +1,3 @@
 query <%= camelize(name) %>FindManyById($idList: [ID]!){
-  <%= camelize(name) %>FindManyById(idList: $idList %>){
-    id,
-    subjectId,
-    <%_ definition.props.filter((p) => p.defType !== 'Entity' && p.defType !== 'EntityArray').map((p) => { -%>
-    <%= camelize(p.name) %>,
-    <%_ }) -%>
-    createdAt,
-    updatedAt
-  }
+  <%= camelize(name) %>FindManyById(idList: $idList %>)<%= gql(index, definition.name, fixtureDepth) %>
 }

--- a/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/queries/__name__-find-one-by-id.gql
+++ b/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/queries/__name__-find-one-by-id.gql
@@ -1,11 +1,3 @@
 query <%= camelize(name) %>FindOneById($id: ID!){
-  <%= camelize(name) %>FindOneById(id: $id %>){
-    id,
-    subjectId,
-    <%_ definition.props.filter((p) => p.defType !== 'Entity' && p.defType !== 'EntityArray').map((p) => { -%>
-    <%= camelize(p.name) %>,
-    <%_ }) -%>
-    createdAt,
-    updatedAt
-  }
+  <%= camelize(name) %>FindOneById(id: $id %>)<%= gql(index, definition.name, fixtureDepth) %>
 }

--- a/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/queries/__name__-find-one-by-subject-id.gql
+++ b/libs/sdk/src/generators/api-e2e/files/src/tests/__name__/gql/queries/__name__-find-one-by-subject-id.gql
@@ -1,11 +1,3 @@
 query <%= camelize(name) %>FindOneBySubjectId($subjectId: String!){
-  <%= camelize(name) %>FindOneBySubjectId(subjectId: $subjectId %>){
-    id,
-    subjectId,
-    <%_ definition.props.filter((p) => p.defType !== 'Entity' && p.defType !== 'EntityArray').map((p) => { -%>
-    <%= camelize(p.name) %>,
-    <%_ }) -%>
-    createdAt,
-    updatedAt
-  }
+  <%= camelize(name) %>FindOneBySubjectId(subjectId: $subjectId %>)<%= gql(index, definition.name, fixtureDepth) %>
 }

--- a/libs/sdk/src/generators/application/application.ts
+++ b/libs/sdk/src/generators/application/application.ts
@@ -7,7 +7,8 @@ import {
   createFiles,
   normalizeOptions,
   toNodeApplicationGeneratorOptions,
-  updateTsConfig
+  updateTsConfigApp,
+  updateTsConfigSpec,
 } from './lib';
 import type { ApplicationGeneratorOptions } from './schema';
 
@@ -27,7 +28,8 @@ export async function applicationGenerator(
   );
 
   createFiles(tree, options);
-  updateTsConfig(tree, options);
+  updateTsConfigApp(tree, options);
+  updateTsConfigSpec(tree, options);
 
   if (!options.skipFormat) {
     await formatFiles(tree);

--- a/libs/sdk/src/generators/application/lib/index.ts
+++ b/libs/sdk/src/generators/application/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './create-files';
 export * from './normalize-options';
-export * from './update-tsconfig';
+export * from './update-tsconfig-app';
+export * from './update-tsconfig-spec';

--- a/libs/sdk/src/generators/application/lib/update-tsconfig-app.ts
+++ b/libs/sdk/src/generators/application/lib/update-tsconfig-app.ts
@@ -2,11 +2,15 @@ import type { Tree } from '@nrwl/devkit';
 import { joinPathFragments, updateJson } from '@nrwl/devkit';
 import type { NormalizedOptions } from '../schema';
 
-export function updateTsConfig(tree: Tree, options: NormalizedOptions): void {
+export function updateTsConfigApp(
+  tree: Tree,
+  options: NormalizedOptions
+): void {
   updateJson(
     tree,
     joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
     (json) => {
+      json.outDir = '../../dist';
       json.compilerOptions.emitDecoratorMetadata = true;
       json.compilerOptions.target = 'es2015';
       return json;

--- a/libs/sdk/src/generators/application/lib/update-tsconfig-spec.ts
+++ b/libs/sdk/src/generators/application/lib/update-tsconfig-spec.ts
@@ -1,0 +1,18 @@
+import type { Tree } from '@nrwl/devkit';
+import { joinPathFragments, updateJson } from '@nrwl/devkit';
+import type { NormalizedOptions } from '../schema';
+
+export function updateTsConfigSpec(
+  tree: Tree,
+  options: NormalizedOptions
+): void {
+  updateJson(
+    tree,
+    joinPathFragments(options.appProjectRoot, 'tsconfig.spec.json'),
+    (json) => {
+      json.compilerOptions.outDir = '../../dist';
+      json.compilerOptions.allowJs = true;
+      return json;
+    }
+  );
+}

--- a/libs/sdk/src/generators/repository/files/repositories/fluree/__name__.fluree.repo.ts
+++ b/libs/sdk/src/generators/repository/files/repositories/fluree/__name__.fluree.repo.ts
@@ -50,7 +50,7 @@ export class <%= classify(name) %><%= classify(type) %>Repository implements I<%
   } 
 
   public async findAll(selectionSetList?: string[]): Promise<<%= classify(name) %>[]> {
-    const select = gqlSelectionSetToFql(selectionSetList); 
+    const select = selectionSetList ? gqlSelectionSetToFql(selectionSetList) : ['*']; 
     const fql = {
       select,
       from: '<%= camelize(name) %>'
@@ -76,7 +76,7 @@ export class <%= classify(name) %><%= classify(type) %>Repository implements I<%
       }
     }
     const fql = compile(spec.build());
-    fql.select = gqlSelectionSetToFql(selectionSetList);
+    fql.select = selectionSetList ? gqlSelectionSetToFql(selectionSetList) : ['*'];
     const result = await this.fluree.query(fql);
     return result.map((f: FlureeSingleObject) => this.mapper.toEntity(f)); 
   }
@@ -84,7 +84,7 @@ export class <%= classify(name) %><%= classify(type) %>Repository implements I<%
   public async findOneById(id: string, selectionSetList?: string[]): Promise<<%= classify(name) %>> {
     const spec = selectOne('*').where(`<%= camelize(name) %>/identifier = '${id}'`).build();
     const fql = compile(spec);
-    fql.selectOne = gqlSelectionSetToFql(selectionSetList);
+    fql.selectOne = selectionSetList ? gqlSelectionSetToFql(selectionSetList) : ['*'];
     const result = await this.fluree.query(fql);
     if (result) {
       return this.mapper.toEntity(result);
@@ -96,7 +96,7 @@ export class <%= classify(name) %><%= classify(type) %>Repository implements I<%
   public async findOneBySubjectId(subjectId: string, selectionSetList?: string[]): Promise<<%= classify(name) %>> {
     const spec = selectOne('*').from(+subjectId).build();
     const fql = compile(spec);
-    fql.selectOne = gqlSelectionSetToFql(selectionSetList);
+    fql.selectOne = selectionSetList ? gqlSelectionSetToFql(selectionSetList) : ['*'];
     const result = await this.fluree.query(fql);
     if (result) {
       return this.mapper.toEntity(result);
@@ -133,7 +133,7 @@ export class <%= classify(name) %><%= classify(type) %>Repository implements I<%
       .where(`<%= camelize(name) %>/<%= camelize(p.name) %> = '${<%= camelize(p.name) %>}'`)
       .build();
     const fql = compile(query);
-    fql.selectOne = gqlSelectionSetToFql(selectionSetList);
+    fql.selectOne = selectionSetList ? gqlSelectionSetToFql(selectionSetList) : ['*'];
     const result = await this.fluree.query(fql);
     if (result) {
       return this.mapper.toEntity(result);
@@ -146,7 +146,7 @@ export class <%= classify(name) %><%= classify(type) %>Repository implements I<%
   public async findAllBy<%= classify(p.name) %>(<%= camelize(p.name) %>: <%= entityProp(p).type %>, selectionSetList?: string[] ): Promise<<%= classify(name)%>[]>{
     const query = select('*').where(`<%= camelize(name) %>/<%= camelize(p.name) %> = '${<%= camelize(p.name) %>}'`).build();
     const fql = compile(query);
-    fql.select = gqlSelectionSetToFql(selectionSetList);
+    fql.select = selectionSetList ? gqlSelectionSetToFql(selectionSetList) : ['*'];
     const result = await this.fluree.query(fql);
     if (result && result.length > 0) {
       return result.map((f: FlureeSingleObject) => this.mapper.toEntity(f));

--- a/libs/sdk/src/generators/utils/constants.ts
+++ b/libs/sdk/src/generators/utils/constants.ts
@@ -1,6 +1,7 @@
 export const asserts = {
   TO_STRICT_EQUAL: 'toStrictEqual',
   TO_BE: 'toBe',
+  TO_STRING_EQUAL_NO_SYS: 'dtoRemoveSystemFields(toStrictEqual',
 };
 
 export const defaults = {

--- a/libs/sdk/src/generators/utils/fixtures/dto/dto.fixture-generator.ts
+++ b/libs/sdk/src/generators/utils/fixtures/dto/dto.fixture-generator.ts
@@ -23,9 +23,8 @@ function generateDtoData(
 
   currentDef.props.map((prop: Property) => {
     if (
-      (prop.defType === DefinitionType.Entity ||
-        prop.defType === DefinitionType.EntityArray) &&
-      !gqlInput
+      prop.defType === DefinitionType.Entity ||
+      prop.defType === DefinitionType.EntityArray
     ) {
       if (currentDepth <= maxDepth) {
         const refDef = defs.find((def: Definition) => def.name === prop.type);

--- a/libs/sdk/src/generators/utils/gql-formatter.ts
+++ b/libs/sdk/src/generators/utils/gql-formatter.ts
@@ -1,0 +1,2 @@
+import { gqlQuery } from './gql/gql.query-generator';
+export const gql = gqlQuery;

--- a/libs/sdk/src/generators/utils/gql/gql.query-generator.constants.ts
+++ b/libs/sdk/src/generators/utils/gql/gql.query-generator.constants.ts
@@ -1,0 +1,6 @@
+export const system = {
+  CREATED_AT: 'createdAt',
+  UPDATED_AT: 'updatedAt',
+  ID: 'id',
+  SUBJECT_ID: 'subjectId',
+};

--- a/libs/sdk/src/generators/utils/gql/gql.query-generator.spec.ts
+++ b/libs/sdk/src/generators/utils/gql/gql.query-generator.spec.ts
@@ -1,0 +1,13 @@
+import { gqlQuery } from './gql.query-generator';
+import * as schema from '../../../../../test/fixtures/code-first/schemas/monolith/canonical/art-marketplace.canonical.schema.json';
+import { CanonicalSchema } from '@logosphere/converters';
+import { system as s } from './gql.query-generator.constants';
+
+describe('GQL query Generator', () => {
+  const s = schema as CanonicalSchema;
+  it('should create GQL query', () => {
+    const query = gqlQuery(s.definitions, 'artwork', 2);
+    expect(query).toBeDefined();
+    console.log(`Generated GQL query: ${query}`);
+  });
+});

--- a/libs/sdk/src/generators/utils/gql/gql.query-generator.ts
+++ b/libs/sdk/src/generators/utils/gql/gql.query-generator.ts
@@ -1,0 +1,55 @@
+import { Definition, DefinitionType, Property } from '@logosphere/converters';
+import { system as s } from './gql.query-generator.constants';
+
+function generateGqlQuery(
+  defs: Definition[],
+  currentDef: Definition,
+  maxDepth = 1,
+  currentDepth = 1,
+  currentPropName = ''
+): string {
+  const indentMinus1 = '\t'.repeat(currentDepth - 1);
+  const indent = '\t'.repeat(currentDepth);
+  let query = `${indentMinus1}${currentPropName} {\n`;
+  query += `${indent}${s.SUBJECT_ID}\n`;
+  query += `${indent}${s.ID}\n`;
+  query += `${indent}${s.CREATED_AT}\n`;
+  query += `${indent}${s.UPDATED_AT}\n`;
+  currentDef.props.map((prop: Property) => {
+    if (
+      prop.defType === DefinitionType.Entity ||
+      prop.defType === DefinitionType.EntityArray
+    ) {
+      if (currentDepth <= maxDepth) {
+        const refDef = defs.find((def: Definition) => def.name === prop.type);
+        query += generateGqlQuery(
+          defs,
+          refDef,
+          maxDepth,
+          currentDepth + 1,
+          prop.name
+        );
+      }
+    } else {
+      query += `${indent}${prop.name}\n`;
+    }
+  });
+  query += `${indentMinus1}}\n`;
+  return query;
+}
+
+/**
+ * Generates nested GQL query from canonical schema
+ * @param defs Canonical schema definitions
+ * @param rootDefName Name of the root definition
+ * @param maxDepth max level of depth for nested data
+ * @returns GQL query
+ */
+export function gqlQuery(
+  defs: Definition[],
+  rootDefName: string,
+  maxDepth = 1
+) {
+  const rootDef = defs.find((d: Definition) => d.name === rootDefName);
+  return generateGqlQuery(defs, rootDef, maxDepth, 1);
+}

--- a/libs/sdk/src/generators/utils/index.ts
+++ b/libs/sdk/src/generators/utils/index.ts
@@ -2,3 +2,5 @@ export * from './normalize-options';
 export * from './run-nest-schematic';
 export * from './types';
 export * as tsFormatter from './ts-formatter';
+export * as gqlFormatter from './gql-formatter';
+export * from './fixtures';

--- a/libs/sdk/src/generators/utils/ts-formatter.ts
+++ b/libs/sdk/src/generators/utils/ts-formatter.ts
@@ -390,11 +390,27 @@ export function dtoDataFixture(
  */
 export function assert(prop: Property): string {
   switch (prop.defType) {
+    case DefinitionType.Entity:
     case DefinitionType.EntityArray:
     case DefinitionType.EnumArray:
     case DefinitionType.ScalarArray:
       return asserts.TO_STRICT_EQUAL;
     default:
       return asserts.TO_BE;
+  }
+}
+
+/**
+ * Asserting DTO in E2E tests
+ * @param prop Canonical schema property
+ * @returns assertion string
+ */
+export function assertDtoE2e(prop: Property, name: string): string {
+  switch (prop.defType) {
+    case DefinitionType.Entity:
+    case DefinitionType.EntityArray:
+      return `dtoRemoveSystemFields(${name})`;
+    default:
+      return name;
   }
 }

--- a/libs/utils/src/dto.constants.ts
+++ b/libs/utils/src/dto.constants.ts
@@ -1,0 +1,6 @@
+export const systemFields = {
+  CREATED_AT: 'createdAt',
+  UPDATED_AT: 'updatedAt',
+  ID: 'id',
+  SUBJECT_ID: 'subjectId',
+};

--- a/libs/utils/src/dto.remove-system-fields.spec.ts
+++ b/libs/utils/src/dto.remove-system-fields.spec.ts
@@ -1,0 +1,44 @@
+import { dtoRemoveSystemFields } from './dto.remove-system-fields';
+describe('Dto remove system fields', () => {
+  const data = {
+    id: 'some id',
+    subjectId: 'some subject id',
+    createdAt: 'yesterday',
+    updatedAt: 'today',
+    something: 'something',
+    moreData: {
+      id: 'some id',
+      subjectId: 'some subject id',
+      createdAt: 'yesterday',
+      updatedAt: 'today',
+      somethingElse: 'something else',
+      yetMoreData: {
+        id: 'some id',
+        subjectId: 'some subject id',
+        createdAt: 'yesterday',
+        updatedAt: 'today',
+        entirelyDifferent: 'entirely different',
+      },
+    },
+  };
+
+  const expected = {
+    something: 'something',
+    moreData: {
+      somethingElse: 'something else',
+      yetMoreData: {
+        entirelyDifferent: 'entirely different',
+      },
+    },
+  };
+
+  it('should remove system fields from object', () => {
+    const newData = dtoRemoveSystemFields(data);
+    expect(newData).toStrictEqual(expected);
+  });
+
+  it('should remove system fields from array of objects', () => {
+    const newData = dtoRemoveSystemFields([data]);
+    expect(newData).toStrictEqual([expected]);
+  });
+});

--- a/libs/utils/src/dto.remove-system-fields.ts
+++ b/libs/utils/src/dto.remove-system-fields.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { systemFields as sf } from './dto.constants';
+
+function removeSystemFields(dto: any): any {
+  const obj = {};
+  Object.keys(dto).map((key: string) => {
+    if (typeof dto[key] === 'object') {
+      obj[key] = removeSystemFields(dto[key]);
+    } else if (
+      key !== sf.ID &&
+      key !== sf.SUBJECT_ID &&
+      key !== sf.CREATED_AT &&
+      key !== sf.UPDATED_AT
+    ) {
+      obj[key] = dto[key];
+    }
+  });
+  return obj;
+}
+
+export function dtoRemoveSystemFields(dto: any): any {
+  return Array.isArray(dto)
+    ? dto.map((d) => removeSystemFields(d))
+    : removeSystemFields(dto);
+}

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from './is-array.util';
 export * from './file.util';
 export * from './gql.util';
+export * from './dto.remove-system-fields';


### PR DESCRIPTION
### Overvew
Fixing e2e tests
- Making referenced entity GQL queries and mutations work

### Issue 
[LOG-215](https://ikigai-technologies.atlassian.net/browse/LOG-215)

### Testing
Tested on PC demo model
```
/* eslint-disable @typescript-eslint/no-unused-vars */
import { Entity, Prop, registerEnum } from '@logosphere/decorators';

export enum Genre
{
    Pop = 0,
    Rock,
    HipHop,
    RnB,
    Country,
    KPop,
    JPop,
    World
};

registerEnum(Genre, 'Genre');

@Entity('artist')
export class Artist {
  @Prop({
    examples: ['Taylor Swift', 'Lil Nas X', 'Dua Lipa']
  })
  name: string;

  @Prop({
    examples: ['About Taylor Swift', 'Lil Nas X Bio', 'Dua Lipa is awesome'],
  })
  about: string;

}

@Entity('album')
export class Album {
  @Prop({
    examples: ['Fearless', 'MONTERO', 'Future Nostalgia'],
    index: true
  })
  name: string;

  @Prop({ type: () => Genre })
  genre: Genre;

  @Prop({ type: () => Artist, index: false })
  artist: Artist;

}
```