### PR TITLE
fix: docker-compose.yaml__template__ missing '='

### DIFF
--- a/libs/sdk/src/generators/api-e2e/files/docker-compose.yaml__tmpl__
+++ b/libs/sdk/src/generators/api-e2e/files/docker-compose.yaml__tmpl__
@@ -37,7 +37,7 @@ services:
       - POSTGRES_LOGGING=true
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_DB=${DB_NAME}
-      - POSTGRES_USER${DB_USER}
+      - POSTGRES_USER=${DB_USER}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     ports:
       - 5432:5432

--- a/libs/sdk/src/generators/docker-compose/files/docker-compose.yaml__template__
+++ b/libs/sdk/src/generators/docker-compose/files/docker-compose.yaml__template__
@@ -37,7 +37,7 @@ services:
       - POSTGRES_LOGGING=true
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_DB=${DB_NAME}
-      - POSTGRES_USER${DB_USER}
+      - POSTGRES_USER=${DB_USER}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     ports:
       - 5432:5432


### PR DESCRIPTION
* Since docker-compose.yaml__template__ POSTGRES_USER is missing `=`, postgres access `psql -U postgres` fails.
* Fixed the template and I confirmed in Codespaces:
  * generated docker-compose.yaml looks good
  * `psql -h localhost -U postgres` to docker composed postgres works as expected. 