### PR TITLE
fix(fluree): add @fluree/crypto-utils peerDependencies

### DIFF
--- a/libs/fluree/package.json
+++ b/libs/fluree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logosphere/fluree",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "./src/index.js",
   "typings": "./index.d.ts",
   "peerDependencies": {


### PR DESCRIPTION
This yields the following dist/libs/fluree/package.json 
```
{
  "name": "@logosphere/fluree",
  "version": "0.5.4",
  "main": "./src/index.js",
  "typings": "./index.d.ts",
  "peerDependencies": {
    "@fluree/crypto-utils": "^1.10.0",
    "@fluree/flureenjs": "1.0.4",
    "@nestjs/common": "9.0.1",
    "@nestjs/config": "2.2.0",
    "axios": "0.26.1",
    "graphql": "16.5.0",
    "lodash": "4.17.21",
    "fs-extra": "10.1.0",
    "path": "0.12.7",
    "safe-stable-stringify": "2.3.1",
    "tslib": "2.4.0"
  },
  "types": "./src/index.d.ts",
  "dependencies": {}
}
```